### PR TITLE
Update targetSDK to 35 and reenable linting on CI

### DIFF
--- a/.changeset/ninety-geckos-sneeze.md
+++ b/.changeset/ninety-geckos-sneeze.md
@@ -1,0 +1,7 @@
+---
+"magicbell-android": minor
+---
+
+Updated the `targetSDK` of both, `sdk` and `sdk-compose` to version `35`
+
+Please follow the _Android SDK Upgrade Assistant_ for upgrading your own apps.

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -31,7 +31,7 @@ jobs:
       run: echo $DATA | base64 -di > ./example/google-services.json
 
     - name: Build with Gradle Wrapper
-      run: ./gradlew build -x lint
+      run: ./gradlew build
 
     - name: Test with Gradle Wrapper
       run: ./gradlew test

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -41,3 +41,11 @@ jobs:
       if: success() || failure() # always run even if the previous step fails
       with:
         report_paths: '**/build/test-results/test*/TEST-*.xml'
+
+    - name: Publish Lint Report
+      uses: yutailang0119/action-android-lint@v4
+      if: success() || failure() # always run even if the previous step fails
+      with:
+        report-path: '**/build/reports/lint-results-*.xml'
+        ignore-warnings: false
+      continue-on-error: false # If annotations contain error of severity, action-android-lint exit 1.

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -10,7 +10,7 @@ android {
   defaultConfig {
     applicationId "com.magicbell.example"
     minSdk 23
-    targetSdk 34
+    targetSdk 35
     versionCode 1
     versionName "1.0"
 

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:fitsSystemWindows="true"
   tools:context=".MainActivity">
 
   <com.google.android.material.appbar.AppBarLayout

--- a/sdk-compose/build.gradle
+++ b/sdk-compose/build.gradle
@@ -10,7 +10,7 @@ android {
 
   defaultConfig {
     minSdk 23
-    targetSdk 33
+    targetSdk 35
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"

--- a/sdk-compose/build.gradle
+++ b/sdk-compose/build.gradle
@@ -10,7 +10,7 @@ android {
 
   defaultConfig {
     minSdk 23
-    targetSdk 31
+    targetSdk 33
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
 
   defaultConfig {
     minSdk 23
-    targetSdk 33
+    targetSdk 35
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
 
   defaultConfig {
     minSdk 23
-    targetSdk 31
+    targetSdk 33
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
## Change description

> [!NOTE]
> This PR depends on other PRs and needs to be rebased on `main` before merge:
> - https://github.com/magicbell/magicbell-android/pull/21

This PR reenables Linting on CI (with PR annotation of linter results) and also fixes linter _errors_ by performing the target SDK upgrade to version `35`.

## Test Plan

Tests run and pass. The example app builds and runs (tested Android 34 and 35 in emulator).

The current set of linter warnings shows up in the _Files changed_ tab:
https://github.com/magicbell/magicbell-android/pull/23/files

## Type of Change

- [ ] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [x] Enhancement  <!-- improves something existing -->

## Guidelines

- [x] A [changeset] is included, or the change is not noteworthy enough to warrant one

<!-- links -->
[changeset]: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#i-am-in-a-single-package-repository