### PR TITLE
Automate Publishing to Maven Central via CI

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,9 +1,7 @@
 name: Changeset
 on:
   push:
-    branches:
-      - main
-      - ullrich/add-changesets
+    branches: [ "main" ]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release-gradle-publish.yml
+++ b/.github/workflows/release-gradle-publish.yml
@@ -1,0 +1,57 @@
+name: Release Gradle Publish
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+  
+    - name: Setup Keyring
+      id: keyring
+      env:
+        KEYRING_FILE: ${{ runner.temp }}/publish-keyring.gpg
+        DATA: ${{ secrets.SIGNING_KEYRING }}
+      run: |
+        echo "Creating Keyring file at $KEYRING_FILE"
+        echo $DATA | base64 -di > $KEYRING_FILE
+        echo "keyringFile=$KEYRING_FILE" >> "$GITHUB_OUTPUT"
+
+    - name: Sanity Check
+      run: |
+        ./gradlew \
+          sdk:lint sdk-compose:lint \
+          sdk:test sdk-compose:test
+
+    - name: Publish to Maven Local
+      run: |
+        ./gradlew \
+          -Psigning.keyId="${{ secrets.SIGNING_KEYID }}" \
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
+          -Psigning.secretKeyRingFile="${{ steps.keyring.outputs.keyringFile }}" \
+          sdk:publishToMavenLocal sdk-compose:publishToMavenLocal
+
+    - name: Publish to Maven
+      run: |
+        ./gradlew \
+          -Psigning.keyId="${{ secrets.SIGNING_KEYID }}" \
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}" \
+          -Psigning.secretKeyRingFile="${{ steps.keyring.outputs.keyringFile }}" \
+          -PNEXUS_USERNAME="${{ secrets.NEXUS_USERNAME }}" \
+          -PNEXUS_PASSWORD="${{ secrets.NEXUS_PASSWORD }}" \
+          sdk:publish sdk-compose:publish


### PR DESCRIPTION
## Change description

This is a simple setup to publish the SDKs to Mave Central. It automates signing and uploading the release.
Currently it is still necessary to promote the build manually in the [Nexus Repository Manager](https://s01.oss.sonatype.org/#welcome). Open "Staging Repository" and promote the artifact (aka Open, Close and Release).

I set out with these goals while working on this PR:

**Goals**
1. **Automate as much as possible**
See above. I'm still looking for ways to automate promoting the artifact to _release_
1. **Keep the config as simple as possible**
I think this PR does this nicely, by not adding additional constraints between the differnt workflows
1. **Only publish if tests are passing** 
I tried solutions that would use worklow logic, and dependend jobs to make the release job fail if the existing build and test CI job failed, but that complicated things to much, so I've opted for running `lint` and `test` tasks inside the publish workflow as sanity checks.
1. **Only publish after a release**
My first attempt was setting up the publish as a dependent workflow of the changesets workflow, by using `workflow_call` primitives, but this collided with goal 2. Using the `on: release` trigger is much simpler and should work equally well. 🤞 
1. **Don't repeat work**
It's hard to Gradle transfer build results between jobs (and convince Gradle to not redo the work!). I experimented with having only one `gradle` workflow, that does everything from building, testing and linting to (conditionally) publishing, but all that collided with goal 2.

Keeping goal 2 a priority, and considering that SDK release workflows don't run often, I generally opted for not optimizing job runtime, but rather to repeat some of the work.

## Current State

I wasn't able to publish the current version using this workflow yet (see steps in testplan), but I hope it's just caused by the fact that version 2.0.0 is already published, and hope that it would work with the next version.

Here's the error, showing that PUT on version 2.0.0 failed.
```
| > Failed to publish publication 'release' to repository 'maven'
|    > Could not PUT 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/com/magicbell/magicbell-sdk/2.0.0/magicbell-sdk-2.0.0.aar'. Received status code 401 from server: Content access is protected by token
```

## Test Plan

Tested that the flow runs locally by using `act` and providing the secrets.

```shell
act -P ubuntu-latest=catthehacker/ubuntu:full-latest \
  -s SIGNING_KEYID -s SIGNING_PASSWORD -s SIGNING_KEYRING \
  -s NEXUS_USERNAME -s NEXUS_PASSWORD \
release
```

Important: This assumes you have the _full_ [act runner image](https://nektosact.com/usage/runners.html) available, which have Android SDK support.

## Type of Change

- [ ] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [ ] Enhancement  <!-- improves something existing -->

## Guidelines

- [ ] A [changeset] is included, or the change is not noteworthy enough to warrant one

<!-- links -->
[changeset]: https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md#i-am-in-a-single-package-repository